### PR TITLE
JSON validation error in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,5 +33,5 @@
   ],
    "dependencies": {
     "jquery": ">=1.9.1"
-  },
+  }
 }


### PR DESCRIPTION
Corrects a json validation error typo in bower.json. The last version of
bower (1.3.7) can't use the file as is. My bad, sorry ...
