### PR TITLE
Add direct support for HTML’s datetime attribute.

### DIFF
--- a/inc/TimeCircles.js
+++ b/inc/TimeCircles.js
@@ -682,7 +682,13 @@
         // Check if a date was passed in html attribute or jquery data
         var attr_data_date = $(this.element).data('date');
         if (typeof attr_data_date === "undefined") {
-            attr_data_date = $(this.element).attr('data-date');
+            // datetime attribute is defined on HTML 5 element <time> for precisely this meaning
+            // is also valid on <ins> and <del>.
+            attr_data_date = $(this.element).attr('datetime');
+            // fallback for when data-date was used, but data() failed to obtain value.
+            if (typeof attr_data_date === "undefined") {
+                attr_data_date = $(this.element).attr('data-date');
+            }
         }
         if (typeof attr_data_date === "string") {
             this.data.attributes.ref_date = parse_date(attr_data_date);


### PR DESCRIPTION
use here with a `<time>` element, though also valid on `<ins>` and `<del>`.

Since `<time>` is specified as indicating a date & time, it is a particularly nice choice for use with TimeCircles, as long as one has set CSS that makes the `<time>` a block element.
